### PR TITLE
Fix Sonar warnings around debug logging and risk manager parameters

### DIFF
--- a/src/birre.py
+++ b/src/birre.py
@@ -150,7 +150,6 @@ def create_birre_server(settings: Dict[str, Any], logger: logging.Logger) -> Fas
         register_company_search_interactive_tool(
             business_server,
             call_v1_tool,
-            call_v2_tool,
             logger=logger,
             default_folder=default_folder,
             default_type=default_type,

--- a/src/config.py
+++ b/src/config.py
@@ -239,13 +239,12 @@ def resolve_birre_settings(
         raw_filter_str if raw_filter_str else DEFAULT_RISK_VECTOR_FILTER
     )
 
-    raw_max_findings = (
-        max_findings_arg
-        if max_findings_arg is not None
-        else max_findings_env
-        if max_findings_env is not None
-        else max_findings_cfg
-    )
+    if max_findings_arg is not None:
+        raw_max_findings = max_findings_arg
+    elif max_findings_env is not None:
+        raw_max_findings = max_findings_env
+    else:
+        raw_max_findings = max_findings_cfg
     try:
         max_findings = _coerce_positive_int(
             raw_max_findings,

--- a/tests/live/test_birre_live.py
+++ b/tests/live/test_birre_live.py
@@ -18,7 +18,7 @@ if str(PROJECT_ROOT) not in sys.path:
 try:
     from fastmcp.client import Client
     from fastmcp.client.client import CallToolResult
-except (ImportError, ModuleNotFoundError):
+except ImportError:
     pytest.skip(
         "fastmcp client not installed; skipping live tests", allow_module_level=True
     )

--- a/tests/unit/test_risk_manager_tools.py
+++ b/tests/unit/test_risk_manager_tools.py
@@ -98,12 +98,9 @@ async def test_company_search_interactive_enriches_results() -> None:
             "getFolders": get_folders_handler,
         }
     )
-    call_v2 = BridgeStub({"getCompanyRequests": lambda _: []})
-
     tool = register_company_search_interactive_tool(
         server,
         call_v1,
-        call_v2,
         logger=logger,
         default_folder="API",
         default_type="continuous_monitoring",

--- a/tests/unit/test_standard_tools.py
+++ b/tests/unit/test_standard_tools.py
@@ -105,14 +105,9 @@ async def test_company_search_interactive_empty_result_contract() -> None:
         assert params == {"expand": "details.employee_count", "name": "Example"}
         return {"results": []}
 
-    async def call_v2_tool(name: str, ctx: Context, params: Dict[str, Any]):
-        await asyncio.sleep(0)
-        raise AssertionError(f"Unexpected v2 call: {name}")
-
     tool = register_company_search_interactive_tool(
         server,
         call_v1_tool,
-        call_v2_tool,
         logger=logger,
         default_folder="Default",
         default_type="continuous",


### PR DESCRIPTION
## Summary
- remove the redundant ModuleNotFoundError handler in the live tests
- ensure `_debug` respects its `None` return contract and simplify subscription helpers
- reuse the risk-manager logger for request audit events and simplify `max_findings` resolution

## Testing
- uv run pytest tests/unit/test_risk_manager_tools.py tests/unit/test_standard_tools.py -k "company_search_interactive or request_company" -q

------
https://chatgpt.com/codex/tasks/task_e_68ec64c65bb0832c9a276d6c6f8572c8