### PR TITLE
Refactor subscription helper to reduce cognitive complexity

### DIFF
--- a/src/business/helpers/subscription.py
+++ b/src/business/helpers/subscription.py
@@ -41,6 +41,104 @@ def _extract_guid_values(response: Dict[str, Any], keys: Sequence[str]) -> List[
     return guids
 
 
+def _subscription_settings_from_env() -> Optional[Dict[str, str]]:
+    """Return the subscription payload base derived from environment variables."""
+
+    folder_name = os.getenv("BIRRE_SUBSCRIPTION_FOLDER")
+    subscription_type = os.getenv("BIRRE_SUBSCRIPTION_TYPE")
+
+    if not folder_name or not subscription_type:
+        return None
+
+    return {
+        "folder": [folder_name],
+        "type": subscription_type,
+    }
+
+
+async def _log_bulk_response(ctx: Context, result: Any, action: str) -> None:
+    """Emit debug logging for bulk subscription responses when enabled."""
+
+    if not coerce_bool(os.getenv("DEBUG")):
+        return
+
+    pretty = (
+        json.dumps(result, indent=2, sort_keys=True)
+        if isinstance(result, dict)
+        else str(result)
+    )
+    await ctx.info(f"manageSubscriptionsBulk({action}) raw response: {pretty}")
+
+
+async def _handle_bulk_errors(
+    ctx: Context, errors: Any, guid: str
+) -> Optional[SubscriptionAttempt]:
+    """Interpret the errors section from the bulk subscription response."""
+
+    if not isinstance(errors, list):
+        return None
+
+    for error in errors:
+        if not isinstance(error, dict):
+            continue
+
+        error_guid = error.get("guid")
+        message = str(error.get("message") or "")
+        normalized_message = message.lower()
+
+        if error_guid and error_guid != guid:
+            continue
+
+        if "already exists" in normalized_message:
+            await ctx.info(
+                f"Company {guid} already subscribed according to bulk response"
+            )
+            return SubscriptionAttempt(True, False, True, message or None)
+
+    if len(errors) > 0:
+        message = f"FastMCP bulk subscription reported errors: {errors}"
+        await ctx.error(message)
+        return SubscriptionAttempt(False, False, False, message)
+
+    return None
+
+
+async def _interpret_manage_subscription_response(
+    ctx: Context, result: Any, guid: str
+) -> SubscriptionAttempt:
+    """Translate the FastMCP bulk response into a SubscriptionAttempt."""
+
+    if not isinstance(result, dict):
+        message = (
+            f"Unexpected response while managing subscription via FastMCP: {result}"
+        )
+        await ctx.error(message)
+        return SubscriptionAttempt(False, False, False, message)
+
+    added_guids = set(_extract_guid_values(result, ("added", "add")))
+    if guid in added_guids:
+        await ctx.info(
+            f"Created temporary subscription for company {guid} using bulk API"
+        )
+        return SubscriptionAttempt(True, True, False)
+
+    attempt = await _handle_bulk_errors(ctx, result.get("errors"), guid)
+    if attempt is not None:
+        return attempt
+
+    modified_guids = set(_extract_guid_values(result, ("modified",)))
+    if guid in modified_guids:
+        await ctx.info(
+            f"Subscription for company {guid} already active (reported as modified)"
+        )
+        return SubscriptionAttempt(True, False, True)
+
+    await ctx.info(
+        f"No add/modify/errors reported for {guid}; assuming already subscribed"
+    )
+    return SubscriptionAttempt(True, False, True)
+
+
 async def create_ephemeral_subscription(
     call_v1_tool: CallV1Tool,
     ctx: Context,
@@ -53,10 +151,9 @@ async def create_ephemeral_subscription(
     try:
         await ctx.info(f"Ensuring BitSight subscription for company: {guid}")
 
-        folder_name = os.getenv("BIRRE_SUBSCRIPTION_FOLDER")
-        subscription_type = os.getenv("BIRRE_SUBSCRIPTION_TYPE")
+        subscription_base = _subscription_settings_from_env()
 
-        if not folder_name or not subscription_type:
+        if not subscription_base:
             message = (
                 "Subscription settings missing: require BIRRE_SUBSCRIPTION_FOLDER and "
                 "BIRRE_SUBSCRIPTION_TYPE (from config/env/CLI)."
@@ -64,86 +161,15 @@ async def create_ephemeral_subscription(
             await ctx.error(message)
             return SubscriptionAttempt(False, False, False, message)
 
-        subscription_payload = {
-            "add": [
-                {
-                    "folder": [folder_name],
-                    "guid": guid,
-                    "type": subscription_type,
-                }
-            ]
-        }
+        subscription_payload = {"add": [{**subscription_base, "guid": guid}]}
 
         result = await call_v1_tool(
             "manageSubscriptionsBulk", ctx, subscription_payload
         )
 
-        # Debug: dump raw API response if DEBUG env is set
-        if coerce_bool(os.getenv("DEBUG")):
-            pretty = (
-                json.dumps(result, indent=2, sort_keys=True)
-                if isinstance(result, dict)
-                else str(result)
-            )
-            await ctx.info(f"manageSubscriptionsBulk(add) raw response: {pretty}")
+        await _log_bulk_response(ctx, result, "add")
 
-        if not isinstance(result, dict):
-            message = (
-                f"Unexpected response while managing subscription via FastMCP: {result}"
-            )
-            await ctx.error(message)
-            return SubscriptionAttempt(False, False, False, message)
-
-        added_guids = set(_extract_guid_values(result, ("added", "add")))
-        if guid in added_guids:
-            await ctx.info(
-                f"Created temporary subscription for company {guid} using bulk API"
-            )
-            return SubscriptionAttempt(True, True, False)
-
-        errors = result.get("errors")
-        if isinstance(errors, list):
-            # If API explicitly reports "already exists" for this guid, treat as
-            # successfully subscribed (no ephemeral cleanup required).
-            for error in errors:
-                if not isinstance(error, dict):
-                    continue
-
-                error_guid = error.get("guid")
-                message = str(error.get("message") or "")
-                normalized_message = message.lower()
-
-                if error_guid and error_guid != guid:
-                    continue
-
-                if "already exists" in normalized_message:
-                    await ctx.info(
-                        f"Company {guid} already subscribed according to bulk response"
-                    )
-                    return SubscriptionAttempt(True, False, True, message or None)
-
-            # Only treat as error if the list is non-empty and we didn't match
-            # an "already exists" scenario. An empty list should not surface an
-            # error and should be considered a no-op.
-            if len(errors) > 0:
-                message = f"FastMCP bulk subscription reported errors: {errors}"
-                await ctx.error(message)
-                return SubscriptionAttempt(False, False, False, message)
-
-        modified_guids = set(_extract_guid_values(result, ("modified",)))
-        if guid in modified_guids:
-            await ctx.info(
-                f"Subscription for company {guid} already active (reported as modified)"
-            )
-            return SubscriptionAttempt(True, False, True)
-
-        # If we reach here, the response didn't explicitly add/modify or report
-        # any actionable error. Treat this as a successful no-op and assume the
-        # subscription is already active to avoid blocking rating retrieval.
-        await ctx.info(
-            f"No add/modify/errors reported for {guid}; assuming already subscribed"
-        )
-        return SubscriptionAttempt(True, False, True)
+        return await _interpret_manage_subscription_response(ctx, result, guid)
 
     except Exception as exc:  # pragma: no cover - defensive logging
         message = f"Failed to ensure subscription for {guid}: {exc}"
@@ -169,14 +195,7 @@ async def cleanup_ephemeral_subscription(
         delete_payload = {"delete": [{"guid": guid}]}
         result = await call_v1_tool("manageSubscriptionsBulk", ctx, delete_payload)
 
-        # Debug: dump raw API response if DEBUG env is set
-        if coerce_bool(os.getenv("DEBUG")):
-            pretty = (
-                json.dumps(result, indent=2, sort_keys=True)
-                if isinstance(result, dict)
-                else str(result)
-            )
-            await ctx.info(f"manageSubscriptionsBulk(delete) raw response: {pretty}")
+        await _log_bulk_response(ctx, result, "delete")
 
         if isinstance(result, dict) and result.get("errors"):
             await ctx.error(


### PR DESCRIPTION
## Summary
- extract helpers for subscription configuration, debug logging, and response handling to simplify `create_ephemeral_subscription`
- share debug logging helper with cleanup routine to keep behaviour consistent while reducing duplication

## Testing
- uv run pytest -m "not live" -v

------
https://chatgpt.com/codex/tasks/task_e_68ed4ae55e4c832ca2b58fe4c9d9d563