### PR TITLE
Adjust online startup check warnings

### DIFF
--- a/src/startup_checks.py
+++ b/src/startup_checks.py
@@ -161,8 +161,9 @@ async def _validate_subscription_folder(
     logger: logging.Logger,
 ) -> bool:
     if not subscription_folder:
-        logger.error(
-            "online.subscription_folder_exists: BIRRE_SUBSCRIPTION_FOLDER not set"
+        logger.warning(
+            "online.subscription_folder_exists: BIRRE_SUBSCRIPTION_FOLDER not set; "
+            "skipping folder validation"
         )
         return True
 
@@ -187,7 +188,10 @@ async def _validate_subscription_quota(
     logger: logging.Logger,
 ) -> bool:
     if not subscription_type:
-        logger.error("online.subscription_quota: BIRRE_SUBSCRIPTION_TYPE not set")
+        logger.warning(
+            "online.subscription_quota: BIRRE_SUBSCRIPTION_TYPE not set; "
+            "skipping quota validation"
+        )
         return True
 
     quota_issue = await _check_subscription_quota(


### PR DESCRIPTION
## Summary
- downgrade missing online subscription configuration messages to warnings and clarify that validation is skipped when not set

## Testing
- uv run pytest -m "not live" -v

------
https://chatgpt.com/codex/tasks/task_e_68ed5d6a9e7c832cbf60e3f1567191fe