### PR TITLE
Fix iterator usage when selecting company domain

### DIFF
--- a/src/business/company_search.py
+++ b/src/business/company_search.py
@@ -93,13 +93,17 @@ def normalize_company_search_results(raw_result: Any) -> Dict[str, Any]:
             "domain": str(
                 next(
                     (
-                        company.get("primary_domain"),
-                        company.get("display_url"),
-                        company.get("domain"),
-                        company.get("company_url"),
+                        value
+                        for value in (
+                            company.get("primary_domain"),
+                            company.get("display_url"),
+                            company.get("domain"),
+                            company.get("company_url"),
+                        )
+                        if value
                     ),
                     "",
-                ) or "",
+                )
             ),
         }
         for company in _extract_companies_data(raw_result)


### PR DESCRIPTION
## Summary
- ensure company search normalization selects the first non-empty domain value using an iterator

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed7474b018832cadd7133e35b02966