### PR TITLE
Refine BiRRe server tests with async call tracking

### DIFF
--- a/tests/unit/test_birre_server.py
+++ b/tests/unit/test_birre_server.py
@@ -1,0 +1,342 @@
+import logging
+import os
+from functools import partial
+
+import pytest
+
+from src import birre
+from src.config import DEFAULT_MAX_FINDINGS, DEFAULT_RISK_VECTOR_FILTER
+
+
+class DummyFastMCP:
+    """Lightweight stand-in for FastMCP to capture constructor arguments."""
+
+    def __init__(self, *, name: str, instructions: str, **kwargs):
+        self.name = name
+        self.instructions = instructions
+        # Mirror FastMCP allowing optional kwargs while tracking unexpected input.
+        self.extra_kwargs = kwargs
+
+
+class AsyncCallRecorder:
+    """Capture async call arguments for fake OpenAPI bridge functions."""
+
+    def __init__(self, label: str):
+        self.label = label
+        self.calls: list[dict[str, object]] = []
+
+    async def __call__(
+        self,
+        api_server: object,
+        tool_name: str,
+        ctx: object,
+        params: dict[str, object],
+        *,
+        logger: logging.Logger,
+    ) -> dict[str, object]:
+        payload = {
+            "api_server": api_server,
+            "tool_name": tool_name,
+            "ctx": ctx,
+            "params": params,
+            "logger": logger,
+        }
+        self.calls.append(payload)
+        return {"label": self.label, "tool": tool_name, "params": params}
+
+
+EXPECTED_V1_KEEP = {
+    "companySearch",
+    "manageSubscriptionsBulk",
+    "getCompany",
+    "getCompaniesFindings",
+    "getFolders",
+    "getCompanySubscriptions",
+}
+
+
+EXPECTED_V2_KEEP = {
+    "getCompanyRequests",
+    "createCompanyRequest",
+    "createCompanyRequestBulk",
+}
+
+
+@pytest.fixture(autouse=True)
+def restore_subscription_env(monkeypatch):
+    monkeypatch.delenv("BIRRE_SUBSCRIPTION_FOLDER", raising=False)
+    monkeypatch.delenv("BIRRE_SUBSCRIPTION_TYPE", raising=False)
+    monkeypatch.delenv("BIRRE_ENABLE_V2", raising=False)
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("birre-tests")
+
+
+@pytest.mark.asyncio
+async def test_create_birre_server_standard_context(monkeypatch, logger):
+    v1_server = object()
+    recorded_calls = {}
+    scheduled = []
+
+    monkeypatch.setattr(birre, "FastMCP", DummyFastMCP)
+    monkeypatch.setattr(
+        birre,
+        "create_v1_api_server",
+        lambda api_key, verify: (api_key, verify, v1_server),
+    )
+
+    def fail_create_v2(*_args, **_kwargs):
+        pytest.fail("create_v2_api_server should not be invoked for the standard context")
+
+    monkeypatch.setattr(birre, "create_v2_api_server", fail_create_v2)
+
+    def capture_schedule(server, keep):
+        scheduled.append((server, set(keep)))
+
+    monkeypatch.setattr(birre, "_schedule_tool_disablement", capture_schedule)
+
+    v1_recorder = AsyncCallRecorder("v1")
+
+    monkeypatch.setattr(birre, "call_v1_openapi_tool", v1_recorder)
+
+    def capture_rating(server, call_v1_tool, *, logger, risk_vector_filter, max_findings):
+        recorded_calls["rating"] = {
+            "server": server,
+            "call_v1_tool": call_v1_tool,
+            "logger": logger,
+            "risk_vector_filter": risk_vector_filter,
+            "max_findings": max_findings,
+        }
+
+    monkeypatch.setattr(birre, "register_company_rating_tool", capture_rating)
+
+    def capture_search(server, call_v1_tool, *, logger):
+        recorded_calls["search"] = {
+            "server": server,
+            "call_v1_tool": call_v1_tool,
+            "logger": logger,
+        }
+
+    monkeypatch.setattr(birre, "register_company_search_tool", capture_search)
+
+    settings = {
+        "api_key": "api-key",
+        "subscription_folder": "/tmp/subscriptions",
+        "subscription_type": "managed",
+    }
+
+    server = birre.create_birre_server(settings, logger)
+
+    assert isinstance(server, DummyFastMCP)
+    assert server.extra_kwargs == {}
+    assert server.name == "io.github.boecht.birre"
+    assert server.instructions == birre.INSTRUCTIONS_MAP["standard"]
+    assert hasattr(server, "call_v1_tool")
+    assert isinstance(server.call_v1_tool, partial)
+    assert server.call_v1_tool.func is v1_recorder
+    assert server.call_v1_tool.args == (("api-key", True, v1_server),)
+    assert server.call_v1_tool.keywords == {"logger": logger}
+
+    ctx = object()
+    params = {"guid": "1234"}
+    result = await server.call_v1_tool("companySearch", ctx, params)
+    assert result == {"label": "v1", "tool": "companySearch", "params": params}
+    assert v1_recorder.calls == [
+        {
+            "api_server": ("api-key", True, v1_server),
+            "tool_name": "companySearch",
+            "ctx": ctx,
+            "params": params,
+            "logger": logger,
+        }
+    ]
+
+    assert recorded_calls["rating"]["risk_vector_filter"] == DEFAULT_RISK_VECTOR_FILTER
+    assert recorded_calls["rating"]["max_findings"] == DEFAULT_MAX_FINDINGS
+    assert "call_v1_tool" in recorded_calls["search"]
+    call_v1_tool = recorded_calls["search"]["call_v1_tool"]
+    assert isinstance(call_v1_tool, partial)
+    assert call_v1_tool.func is v1_recorder
+    assert call_v1_tool.args == (("api-key", True, v1_server),)
+    assert call_v1_tool.keywords == {"logger": logger}
+
+    assert scheduled == [(("api-key", True, v1_server), EXPECTED_V1_KEEP)]
+
+    assert os.environ["BIRRE_SUBSCRIPTION_FOLDER"] == "/tmp/subscriptions"
+    assert os.environ["BIRRE_SUBSCRIPTION_TYPE"] == "managed"
+    assert not hasattr(server, "call_v2_tool")
+
+
+@pytest.mark.asyncio
+async def test_create_birre_server_risk_manager_context(monkeypatch, logger):
+    v1_server = object()
+    v2_server = object()
+    scheduled = []
+    captures = {}
+
+    monkeypatch.setattr(birre, "FastMCP", DummyFastMCP)
+    monkeypatch.setattr(
+        birre,
+        "create_v1_api_server",
+        lambda api_key, verify: (api_key, verify, v1_server),
+    )
+    monkeypatch.setattr(
+        birre,
+        "create_v2_api_server",
+        lambda api_key, verify: (api_key, verify, v2_server),
+    )
+
+    def capture_schedule(server, keep):
+        scheduled.append((server, set(keep)))
+
+    monkeypatch.setattr(birre, "_schedule_tool_disablement", capture_schedule)
+
+    v1_recorder = AsyncCallRecorder("v1")
+    v2_recorder = AsyncCallRecorder("v2")
+
+    monkeypatch.setattr(birre, "call_v1_openapi_tool", v1_recorder)
+    monkeypatch.setattr(birre, "call_v2_openapi_tool", v2_recorder)
+
+    def capture_rating(server, call_v1_tool, *, logger, risk_vector_filter, max_findings):
+        captures.setdefault("rating", []).append((server, risk_vector_filter, max_findings))
+
+    monkeypatch.setattr(birre, "register_company_rating_tool", capture_rating)
+
+    def capture_search(server, call_v1_tool, *, logger):
+        captures.setdefault("search", []).append(server)
+
+    monkeypatch.setattr(birre, "register_company_search_tool", capture_search)
+
+    import src.business.risk_manager as risk_manager
+
+    def capture_interactive(server, call_v1_tool, *, logger, default_folder, default_type, max_findings):
+        captures.setdefault("interactive", []).append((default_folder, default_type, max_findings))
+
+    def capture_manage(server, call_v1_tool, *, logger, default_folder, default_type):
+        captures.setdefault("manage", []).append((default_folder, default_type))
+
+    def capture_request(server, call_v1_tool, call_v2_tool, *, logger, default_folder, default_type):
+        captures.setdefault("request", []).append((default_folder, default_type))
+
+    monkeypatch.setattr(risk_manager, "register_company_search_interactive_tool", capture_interactive)
+    monkeypatch.setattr(risk_manager, "register_manage_subscriptions_tool", capture_manage)
+    monkeypatch.setattr(risk_manager, "register_request_company_tool", capture_request)
+
+    settings = {
+        "api_key": "key",
+        "context": "risk_manager",
+        "subscription_folder": "folder",
+        "subscription_type": "type",
+        "max_findings": 7,
+        "risk_vector_filter": "compromised_hosts",
+    }
+
+    server = birre.create_birre_server(settings, logger)
+
+    assert isinstance(server, DummyFastMCP)
+    assert server.extra_kwargs == {}
+    assert server.name == "io.github.boecht.birre"
+    assert server.instructions == birre.INSTRUCTIONS_MAP["risk_manager"]
+    assert hasattr(server, "call_v1_tool")
+    assert hasattr(server, "call_v2_tool")
+    assert server.call_v1_tool.func is v1_recorder
+    assert server.call_v1_tool.args == (("key", True, v1_server),)
+    assert server.call_v1_tool.keywords == {"logger": logger}
+    assert server.call_v2_tool.func is v2_recorder
+    assert server.call_v2_tool.args == (("key", True, v2_server),)
+    assert server.call_v2_tool.keywords == {"logger": logger}
+
+    ctx = object()
+    params_v1 = {"tool": "search"}
+    params_v2 = {"tool": "request"}
+    await server.call_v1_tool("companySearch", ctx, params_v1)
+    await server.call_v2_tool("getCompanyRequests", ctx, params_v2)
+
+    assert v1_recorder.calls == [
+        {
+            "api_server": ("key", True, v1_server),
+            "tool_name": "companySearch",
+            "ctx": ctx,
+            "params": params_v1,
+            "logger": logger,
+        }
+    ]
+    assert v2_recorder.calls == [
+        {
+            "api_server": ("key", True, v2_server),
+            "tool_name": "getCompanyRequests",
+            "ctx": ctx,
+            "params": params_v2,
+            "logger": logger,
+        }
+    ]
+
+    assert captures["rating"] == [(server, "compromised_hosts", 7)]
+    assert captures["search"] == [server]
+    assert captures["interactive"] == [("folder", "type", 7)]
+    assert captures["manage"] == [("folder", "type")]
+    assert captures["request"] == [("folder", "type")]
+
+    assert scheduled == [
+        (("key", True, v1_server), EXPECTED_V1_KEEP),
+        (("key", True, v2_server), EXPECTED_V2_KEEP),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_birre_server_enables_v2_via_env(monkeypatch, logger):
+    v1_server = object()
+    v2_server = object()
+    scheduled = []
+
+    monkeypatch.setattr(birre, "FastMCP", DummyFastMCP)
+    monkeypatch.setattr(
+        birre,
+        "create_v1_api_server",
+        lambda api_key, verify: (api_key, verify, v1_server),
+    )
+
+    def fake_create_v2(api_key, verify):
+        return api_key, verify, v2_server
+
+    monkeypatch.setattr(birre, "create_v2_api_server", fake_create_v2)
+
+    def capture_schedule(server, keep):
+        scheduled.append((server, set(keep)))
+
+    monkeypatch.setattr(birre, "_schedule_tool_disablement", capture_schedule)
+
+    v1_recorder = AsyncCallRecorder("v1")
+    v2_recorder = AsyncCallRecorder("v2")
+
+    monkeypatch.setattr(birre, "call_v1_openapi_tool", v1_recorder)
+    monkeypatch.setattr(birre, "call_v2_openapi_tool", v2_recorder)
+    monkeypatch.setattr(birre, "register_company_rating_tool", lambda *args, **kwargs: None)
+    monkeypatch.setattr(birre, "register_company_search_tool", lambda *args, **kwargs: None)
+
+    monkeypatch.setenv("BIRRE_ENABLE_V2", "true")
+
+    server = birre.create_birre_server({"api_key": "key"}, logger)
+
+    assert hasattr(server, "call_v2_tool")
+    assert server.name == "io.github.boecht.birre"
+    assert server.extra_kwargs == {}
+    assert server.call_v1_tool.func is v1_recorder
+    assert server.call_v1_tool.args == (("key", True, v1_server),)
+    assert server.call_v1_tool.keywords == {"logger": logger}
+    assert server.call_v2_tool.func is v2_recorder
+    assert server.call_v2_tool.args == (("key", True, v2_server),)
+    assert server.call_v2_tool.keywords == {"logger": logger}
+
+    await server.call_v1_tool("companySearch", object(), {})
+    await server.call_v2_tool("getCompanyRequests", object(), {})
+
+    assert v1_recorder.calls[0]["api_server"] == ("key", True, v1_server)
+    assert v2_recorder.calls[0]["api_server"] == ("key", True, v2_server)
+
+    assert scheduled == [
+        (("key", True, v1_server), EXPECTED_V1_KEEP),
+        (("key", True, v2_server), EXPECTED_V2_KEEP),
+    ]

--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -1,0 +1,46 @@
+import pytest
+
+from src.constants import FALSY_STRINGS, TRUTHY_STRINGS, coerce_bool
+
+
+@pytest.mark.parametrize("value", sorted(TRUTHY_STRINGS))
+def test_coerce_bool_truthy_strings(value: str) -> None:
+    assert coerce_bool(value) is True
+    assert coerce_bool(value.upper()) is True
+    assert coerce_bool(f"  {value}  ") is True
+
+
+@pytest.mark.parametrize("value", [True, 1, 3.14])
+def test_coerce_bool_truthy_non_strings(value: object) -> None:
+    assert coerce_bool(value) is True
+
+
+@pytest.mark.parametrize("value", sorted(FALSY_STRINGS))
+def test_coerce_bool_falsy_strings(value: str) -> None:
+    assert coerce_bool(value, default=True) is False
+    assert coerce_bool(value.upper(), default=True) is False
+    assert coerce_bool(f"  {value}  ", default=True) is False
+
+
+class UnstableBool:
+    def __init__(self, *, raises: bool) -> None:
+        self._raises = raises
+
+    def __bool__(self) -> bool:
+        if self._raises:
+            raise ValueError("boom")
+        return False
+
+
+@pytest.mark.parametrize("value", [False, 0, 0.0, UnstableBool(raises=False)])
+def test_coerce_bool_falsy_non_strings(value: object) -> None:
+    assert coerce_bool(value, default=True) is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    [None, "", "maybe", UnstableBool(raises=True)],
+)
+def test_coerce_bool_falls_back_to_default(value: object) -> None:
+    assert coerce_bool(value, default=True) is True
+    assert coerce_bool(value, default=False) is False

--- a/tests/unit/test_server_cli.py
+++ b/tests/unit/test_server_cli.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import sys
 from types import SimpleNamespace
@@ -88,6 +89,7 @@ def test_main_runs_server_when_checks_pass(monkeypatch: pytest.MonkeyPatch) -> N
         patch("server.run_offline_startup_checks", return_value=True) as offline_mock,
         patch("server.run_online_startup_checks", async_online) as online_mock,
         patch("server.create_birre_server", return_value=fake_server) as create_server,
+        patch("server.asyncio.run", wraps=asyncio.run) as asyncio_run,
     ):
         server.main()
 
@@ -104,5 +106,7 @@ def test_main_runs_server_when_checks_pass(monkeypatch: pytest.MonkeyPatch) -> N
     create_kwargs = create_server.call_args.kwargs
     assert create_kwargs["settings"] == runtime_settings
     assert create_kwargs["logger"] is root_logger
+
+    asyncio_run.assert_called_once()
 
     fake_server.run.assert_called_once()

--- a/tests/unit/test_startup_checks.py
+++ b/tests/unit/test_startup_checks.py
@@ -8,6 +8,19 @@ from src import startup_checks
 from src.startup_checks import run_offline_startup_checks
 
 
+class DummyCallV1:
+    def __init__(self, responses: dict[str, object]) -> None:
+        self._responses = responses
+        self.calls: list[str] = []
+
+    async def __call__(self, name: str, ctx: object, payload: dict[str, object]) -> object:
+        self.calls.append(name)
+        response = self._responses.get(name)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
 def test_offline_checks_fail_without_api_key(caplog: pytest.LogCaptureFixture) -> None:
     logger = logging.getLogger("birre.startup.test")
     caplog.set_level(logging.CRITICAL)
@@ -68,3 +81,161 @@ def test_offline_checks_success_logs_debug_and_warnings(
         "offline.config.subscription_type: BIRRE_SUBSCRIPTION_TYPE not set"
         in warning_messages
     )
+
+
+@pytest.mark.asyncio
+async def test_online_checks_skipped(caplog: pytest.LogCaptureFixture) -> None:
+    logger = logging.getLogger("birre.startup.online.skipped")
+    caplog.set_level(logging.WARNING)
+
+    result = await startup_checks.run_online_startup_checks(
+        call_v1_tool=DummyCallV1({}),
+        subscription_folder=None,
+        subscription_type=None,
+        logger=logger,
+        skip_startup_checks=True,
+    )
+
+    assert result is True
+    assert any(
+        record.levelno == logging.WARNING
+        and record.message
+        == "online.startup_checks_skipped: Startup online checks skipped on request"
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_online_checks_missing_call_tool(caplog: pytest.LogCaptureFixture) -> None:
+    logger = logging.getLogger("birre.startup.online.missing")
+    caplog.set_level(logging.CRITICAL)
+
+    result = await startup_checks.run_online_startup_checks(
+        call_v1_tool=None,  # type: ignore[arg-type]
+        subscription_folder=None,
+        subscription_type=None,
+        logger=logger,
+    )
+
+    assert result is False
+    assert any(
+        record.levelno == logging.CRITICAL
+        and record.message == "online.api_connectivity: v1 call tool unavailable"
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_online_checks_connectivity_failure(caplog: pytest.LogCaptureFixture) -> None:
+    logger = logging.getLogger("birre.startup.online.connectivity")
+    caplog.set_level(logging.CRITICAL)
+
+    call_v1 = DummyCallV1({"companySearch": RuntimeError("boom")})
+
+    result = await startup_checks.run_online_startup_checks(
+        call_v1_tool=call_v1,
+        subscription_folder=None,
+        subscription_type=None,
+        logger=logger,
+    )
+
+    assert result is False
+    assert call_v1.calls == ["companySearch"]
+    assert any(
+        record.levelno == logging.CRITICAL
+        and record.message.startswith("online.api_connectivity: RuntimeError: boom")
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_online_checks_folder_failure(caplog: pytest.LogCaptureFixture) -> None:
+    logger = logging.getLogger("birre.startup.online.folder")
+    caplog.set_level(logging.INFO)
+
+    call_v1 = DummyCallV1(
+        {
+            "companySearch": {"results": []},
+            "getFolders": [{"name": "Other"}],
+        }
+    )
+
+    result = await startup_checks.run_online_startup_checks(
+        call_v1_tool=call_v1,
+        subscription_folder="Target",
+        subscription_type=None,
+        logger=logger,
+    )
+
+    assert result is False
+    assert call_v1.calls == ["companySearch", "getFolders"]
+    assert any(
+        record.levelno == logging.CRITICAL
+        and "online.subscription_folder_exists" in record.message
+        and "Target" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_online_checks_quota_failure(caplog: pytest.LogCaptureFixture) -> None:
+    logger = logging.getLogger("birre.startup.online.quota")
+    caplog.set_level(logging.INFO)
+
+    call_v1 = DummyCallV1(
+        {
+            "companySearch": {"results": []},
+            "getFolders": [{"name": "Target"}],
+            "getCompanySubscriptions": {
+                "continuous_monitoring": {"remaining": 0}
+            },
+        }
+    )
+
+    result = await startup_checks.run_online_startup_checks(
+        call_v1_tool=call_v1,
+        subscription_folder="Target",
+        subscription_type="continuous_monitoring",
+        logger=logger,
+    )
+
+    assert result is False
+    assert call_v1.calls == ["companySearch", "getFolders", "getCompanySubscriptions"]
+    assert any(
+        record.levelno == logging.CRITICAL
+        and "online.subscription_quota" in record.message
+        and "no remaining licenses" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_online_checks_success(caplog: pytest.LogCaptureFixture) -> None:
+    logger = logging.getLogger("birre.startup.online.success")
+    caplog.set_level(logging.INFO)
+
+    call_v1 = DummyCallV1(
+        {
+            "companySearch": {"results": []},
+            "getFolders": [{"name": "Target"}],
+            "getCompanySubscriptions": {
+                "continuous_monitoring": {"remaining": 2}
+            },
+        }
+    )
+
+    result = await startup_checks.run_online_startup_checks(
+        call_v1_tool=call_v1,
+        subscription_folder="Target",
+        subscription_type="continuous_monitoring",
+        logger=logger,
+    )
+
+    assert result is True
+    assert call_v1.calls == ["companySearch", "getFolders", "getCompanySubscriptions"]
+    expected_messages = {
+        "online.api_connectivity: Successfully called companySearch",
+        "online.subscription_folder_exists: Folder 'Target' verified via API",
+        "online.subscription_quota: Subscription 'continuous_monitoring' has remaining licenses",
+    }
+    assert expected_messages.issubset({record.message for record in caplog.records})


### PR DESCRIPTION
## Summary
- introduce an async call recorder helper in the BiRRe server tests to verify tool partials execute with the expected payload
- convert the BiRRe server scenarios to async tests that exercise the recorded call paths and reuse shared keep-set constants

## Testing
- uv run pytest tests/unit/test_birre_server.py -q
- uv run pytest -m "not live" -q

------
https://chatgpt.com/codex/tasks/task_e_68ed78243fe0832cb31a61780913c999