### PR TITLE
Fix FastMCP instructions type

### DIFF
--- a/src/birre.py
+++ b/src/birre.py
@@ -23,15 +23,14 @@ from .business import (
 )
 
 
-INSTRUCTIONS_MAP = {
+INSTRUCTIONS_MAP: Dict[str, str] = {
     "standard": (
         "BitSight rating retriever. Use `company_search` to locate a company, "
-        "then call `get_company_rating` with the chosen GUID.",
+        "then call `get_company_rating` with the chosen GUID."
     ),
     "risk_manager": (
-        "Risk manager persona. Start with `company_search_interactive` to review "
-        "matches, call `manage_subscriptions` to adjust coverage, and use "
-        "`request_company` when an entity is missing.",
+        "Risk manager persona. Start with `company_search_interactive` to review matches, "
+        "call `manage_subscriptions` to adjust coverage, and use `request_company` when an entity is missing."
     ),
 }
 


### PR DESCRIPTION
## Summary
- ensure the FastMCP initialization instructions map stores plain strings to satisfy pydantic validation

## Testing
- uv run pytest -m "not live" -v

------
https://chatgpt.com/codex/tasks/task_e_68ede65b82b4832cb2ec013618ab86ab