### PR TITLE
Gracefully handle KeyboardInterrupt shutdown in server

### DIFF
--- a/server.py
+++ b/server.py
@@ -211,7 +211,18 @@ def main() -> None:
         raise SystemExit(1)
 
     logger.info("Starting BiRRe FastMCP server")
-    server.run()
+    try:
+        server.run()
+    except KeyboardInterrupt:
+        print(
+            "\n"
+            "╭────────────────────────────────────────╮\n"
+            "│\033[0;31m  Keyboard interrupt received — stopping  \033[0m│\n"
+            "│\033[0;31m          BiRRe FastMCP server            \033[0m│\n"
+            "╰────────────────────────────────────────╯\n\033[0m",
+            file=sys.stderr,
+        )
+        logger.info("BiRRe FastMCP server stopped via KeyboardInterrupt")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- wrap the server run call in a KeyboardInterrupt handler so Ctrl+C exits cleanly without a traceback
- emit a concise shutdown banner and log entry when the server is interrupted

## Testing
- python -m compileall server.py

------
https://chatgpt.com/codex/tasks/task_e_68ee08f3d0f4832ca7e7c2cd978579e5