### PR TITLE
Enforce roles-only placement for context-related configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ BiRRe now supports context-specific toolsets:
   - `request_company`: Submit BitSight company requests (deduplicates existing requests, attempts v2 bulk workflow with folder targeting, falls back gracefully)
   - `company_search` and `get_company_rating` remain available for spot checks
 
-Select a context via `--context`, `BIRRE_CONTEXT`, or the `[runtime].context` config key. Invalid values default to `standard` with a warning.
+Select a context via `--context`, `BIRRE_CONTEXT`, or the `[roles].context` config key. Invalid values default to `standard` with a warning.
 
 ## BitSight API Documentation (v1 + v2 are complementary)
 
@@ -99,7 +99,7 @@ Select a context via `--context`, `BIRRE_CONTEXT`, or the `[runtime].context` co
 - **Top Findings Summary**: Attach the most impactful vulnerabilities to the rating payload, using relaxed severity filters (severe/material first, then moderate with web-appsec padding when needed)
 - **Enhanced Sorting**: Prioritise findings by severity, asset importance, and recency to keep the worst issues on top
 - **Narrative Improvements**: Normalise detection/remediation text for quick consumption by MCP clients
-- **Configuration Hooks**: Continue to rely on v1 findings endpoints while keeping v2 tooling optional via `BIRRE_ENABLE_V2`
+- **Configuration Hooks**: Continue to rely on v1 findings endpoints while automatically loading the complementary v2 tooling when the risk-manager context is active
 
 ### Version 3.0: Context Modes (Current)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,12 +109,12 @@ Reference: FastMCP tool management documentation at <https://gofastmcp.com/serve
 - Ephemeral subscription lifecycle management (create/cleanup)
 - Severity-aware top findings ranking (BitSight findings API)
 - Error handling and response normalization
-- Optional v2 preloading via `BIRRE_ENABLE_V2` for complementary endpoints (used when workflows require functionality v1 does not offer, such as bulk company requests)
+- Automatic v2 preloading when the risk-manager context is active for complementary endpoints (used when workflows require functionality v1 does not offer, such as bulk company requests)
 
 ### API Version Strategy
 
 - **v1 API (Primary)**: All shipping business tools rely exclusively on v1 endpoints for search, ratings, findings, folder lookups, and subscription management. Non-essential v1 tools are disabled at startup to minimise surface area.
-- **v2 API (Complementary)**: The v2 schema can be preloaded by setting `BIRRE_ENABLE_V2=true`. Business tooling invokes v2 only when it provides capabilities unavailable in v1 (e.g., bulk onboarding), so runtime behaviour remains v1-centric unless optional features require it.
+- **v2 API (Complementary)**: The v2 schema loads automatically whenever the `risk_manager` context is selected. Business tooling invokes v2 only when it provides capabilities unavailable in v1 (e.g., bulk onboarding), so runtime behaviour remains v1-centric unless complementary features require it.
 - **Future Work**: Targeted v2 integrations (e.g., richer findings or financial metrics) will continue to be layered on per feature; v2 augments v1 and there is no plan for a wholesale replacement.
 
 ## Implementation Details

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -5,7 +5,7 @@
 - **Purpose:** Build a general-purpose MCP server for the BitSight security rating platform. This server exposes BitSight data retrieval/functionality as callable MCP "tools" (endpoints) to any client able to speak the Model Context Protocol (MCP).
 - **MCP Role:** This is a backend service ("MCP server"), not an LLM client, plugin, or IDE extension. It responds to standardized MCP method calls from AI clients; it does not initiate them.
 - **Deployment:** Service can be run locally or remotely (cloud/server), and must support multi-tenant LLM/AI agent access, with basic authentication in advanced versions.
-- **BitSight Interaction:** Business tools call BitSight v1 endpoints via FastMCP. The v2 schema is preloaded (enable with `BIRRE_ENABLE_V2=true`) for complementary features—v2 augments v1 and is used where it adds capabilities (e.g., bulk company requests).
+- **BitSight Interaction:** Business tools call BitSight v1 endpoints via FastMCP. The v2 schema is bundled and loads automatically when the `risk_manager` context is active to support complementary features (e.g., bulk company requests).
 
 ## 2. Functional Requirements, by Version
 
@@ -67,13 +67,13 @@
 ### Version 3.0 – Context Modes for Targeted Workflows
 
 - **Purpose:** Provide two streamlined server personas that expose only the tooling each role needs while preserving the underlying v1 FastMCP workflow.
-- **Context Selection:** Server accepts a context parameter (CLI flag `--context`, env `BIRRE_CONTEXT`, or config). Invalid values fall back to the default standard context with a warning.
+- **Context Selection:** Server accepts a context parameter (CLI flag `--context`, env `BIRRE_CONTEXT`, or config via `[roles].context`). Invalid values fall back to the default standard context with a warning.
 
 #### Context Definitions
 
 - **`standard` (default)**
   - **Audience:** Everyday users and agents that only need quick, single-company ratings.
-  - **Tools exposed:** `get_company_rating` (and any light-weight diagnostics required for support).
+  - **Tools exposed:** `company_search`, `get_company_rating` (and any light-weight diagnostics required for support).
   - **Behaviour:** Company lookup remains AI-driven (callers rely on upstream tooling to choose the GUID); rating tool continues to auto-manage ephemeral subscriptions.
 
 - **`risk_manager`**

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -53,7 +53,7 @@
 
 ### Version 3.0 (Context Modes) — Functionally complete, needs hardening
 
-- Context selection now respected via CLI (`--context`), environment (`BIRRE_CONTEXT`), and config defaults
+- Context selection now respected via CLI (`--context`), environment (`BIRRE_CONTEXT`), and config defaults (`[roles].context`)
 - `risk_manager` persona ships with `company_search_interactive`, `manage_subscriptions`, and `request_company`; each tool returns enriched metadata and guidance for LLM-driven human confirmation (no direct `ctx.prompt` usage)
 - BitSight v2 bridge is auto-loaded for the request workflow (bulk path attempted, single-request fallback retained)
 - Offline unit tests exercise dry-run and fallback behaviour; live FastMCP smoke tests now cover the company search + rating workflows.

--- a/tests/unit/test_config_runtime.py
+++ b/tests/unit/test_config_runtime.py
@@ -37,9 +37,16 @@ def write_config(path: Path, *, include_api_key: bool) -> None:
         "skip_startup_checks = false",
         "debug = false",
     ]
+    roles_block = [
+        "[roles]",
+        'context = "standard"',
+        f'risk_vector_filter = "{DEFAULT_RISK_VECTOR_FILTER}"',
+        f"max_findings = {DEFAULT_MAX_FINDINGS}",
+    ]
 
     path.write_text(
-        "\n".join(bitsight_block + ["", *runtime_block]) + "\n", encoding="utf-8"
+        "\n".join(bitsight_block + ["", *runtime_block, "", *roles_block]) + "\n",
+        encoding="utf-8",
     )
 
 
@@ -200,7 +207,7 @@ def test_invalid_context_falls_back_to_standard_with_warning(
                 "subscription_folder = \"API\"",
                 "subscription_type = \"continuous_monitoring\"",
                 "",
-                "[runtime]",
+                "[roles]",
                 "context = \"invalid\"",
             ]
         )
@@ -376,3 +383,30 @@ def test_allow_insecure_tls_overrides_ca_bundle_with_warning(
     assert settings["warnings"] == [
         "allow_insecure_tls takes precedence over ca_bundle_path; HTTPS verification will be disabled"
     ]
+
+
+def test_roles_settings_misplaced_in_runtime_section_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    base = tmp_path / DEFAULT_CONFIG_FILENAME
+    base.write_text(
+        "\n".join(
+            [
+                "[bitsight]",
+                'subscription_folder = "API"',
+                'subscription_type = "continuous_monitoring"',
+                "",
+                "[runtime]",
+                'context = "standard"',
+                "skip_startup_checks = false",
+                "debug = false",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("BITSIGHT_API_KEY", "env-key")
+
+    with pytest.raises(ValueError, match=r"Misplaced configuration keys context"):
+        resolve_birre_settings(config_path=str(base))


### PR DESCRIPTION
## Summary
- add validation that raises when context defaults are configured under the [runtime] section
- remove legacy base-layer lookup and rely on the primary config when constructing layered sections
- extend the runtime configuration tests to cover misplacement errors

## Testing
- uv run pytest -m "not live" -v

------
https://chatgpt.com/codex/tasks/task_e_68f3eae333c4832ca21e07bb4a94f8c0