### PR TITLE
Use prance ResolvingParser for API client schemas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "fastmcp==2.12.4",
     "python-dotenv",
     "httpx",
+    "prance>=23.6.7",
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-mock>=3.12.0",


### PR DESCRIPTION
## Summary
- add the prance dependency so OpenAPI specs can be validated and resolved automatically
- load API schemas with prance's ResolvingParser and wrap schema-only responses with application/json content based on component descriptions
- keep client construction unchanged while relying on the validated specifications

## Testing
- uv run pytest -m "not live" -v

------
https://chatgpt.com/codex/tasks/task_e_68f5508c5f08832c8d2db572d5991411