### PR TITLE
Refactor server CLI to Typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-mock>=3.12.0",
+    "typer>=0.12.3",
+    "rich>=13.7.0",
+    "typing_extensions>=4.9.0",
 ]
 
 [project.urls]

--- a/server.py
+++ b/server.py
@@ -1,17 +1,16 @@
-"""BiRRe FastMCP server entrypoint.
+"""BiRRe FastMCP server entrypoint."""
 
-Usage:
-    python server.py [--bitsight-api-key KEY]
-
-If no key is supplied, the server falls back to the ``BITSIGHT_API_KEY``
-environment variable.
-"""
-
-import argparse
 import asyncio
 import logging
 import os
 import sys
+from dataclasses import replace
+from typing import Optional, Sequence
+
+import typer
+from rich.console import Console
+from typing_extensions import Annotated
+from typer.main import get_command
 
 # FastMCP checks this flag during import time, so ensure it is enabled before
 # importing any modules that depend on FastMCP.
@@ -19,8 +18,7 @@ os.environ["FASTMCP_EXPERIMENTAL_ENABLE_NEW_OPENAPI_PARSER"] = "true"
 
 from src.birre import create_birre_server
 from src.constants import DEFAULT_CONFIG_FILENAME
-from dataclasses import replace
-
+from src.logging import configure_logging
 from src.settings import (
     LoggingInputs,
     RuntimeInputs,
@@ -31,165 +29,27 @@ from src.settings import (
     logging_from_settings,
     runtime_from_settings,
 )
-from src.logging import configure_logging
 from src.startup_checks import run_offline_startup_checks, run_online_startup_checks
 
+console = Console(stderr=True)
 
-def main() -> None:
-    """Main entry point for BiRRe MCP server."""
+app = typer.Typer(
+    help="Run the BiRRe FastMCP server",
+    rich_markup_mode="rich",
+)
 
-    parser = argparse.ArgumentParser(description="Run the BiRRe FastMCP server")
-    parser.add_argument(
-        "--bitsight-api-key",
-        dest="api_key",
-        help="BitSight API key (overrides BITSIGHT_API_KEY env var)",
-    )
-    parser.add_argument(
-        "--config",
-        dest="config_path",
-        default=DEFAULT_CONFIG_FILENAME,
-        help=(
-            "Path to BiRRe config TOML "
-            f"(default: {DEFAULT_CONFIG_FILENAME})"
-        ),
-    )
-    parser.add_argument(
-        "--context",
-        dest="context",
-        help="Tool persona to expose (standard or risk_manager)",
-    )
-    valid_levels = [
-        name
-        for name, value in logging.getLevelNamesMapping().items()
-        if isinstance(name, str) and not name.isdigit()
-    ]
-    parser.add_argument(
-        "--log-level",
-        dest="log_level",
-        choices=sorted(valid_levels),
-        help="Logging level (defaults to INFO unless overridden)",
-    )
-    parser.add_argument(
-        "--log-format",
-        dest="log_format",
-        choices=["text", "json"],
-        help="Logging format (text or json)",
-    )
-    parser.add_argument(
-        "--log-file",
-        dest="log_file",
-        help="Log file path (adds rotating file handler)",
-    )
-    parser.add_argument(
-        "--log-max-bytes",
-        dest="log_max_bytes",
-        type=int,
-        help="Maximum size in bytes for rotating log files",
-    )
-    parser.add_argument(
-        "--log-backup-count",
-        dest="log_backup_count",
-        type=int,
-        help="Number of rotating log file backups to keep",
-    )
-    parser.add_argument(
-        "--skip-startup-checks",
-        dest="skip_startup_checks",
-        action="store_true",
-        default=None,
-        help="Skip BitSight startup checks (not recommended)",
-    )
-    parser.add_argument(
-        "--subscription-folder",
-        dest="subscription_folder",
-        help="Preferred BitSight subscription folder name (e.g. API), must exist",
-    )
-    parser.add_argument(
-        "--subscription-type",
-        dest="subscription_type",
-        help="BitSight subscription type (e.g. continuous_monitoring)",
-    )
-    parser.add_argument(
-        "--risk-vector-filter",
-        dest="risk_vector_filter",
-        help="Override the default risk vectors used for top findings (comma-separated).",
-    )
-    parser.add_argument(
-        "--max-findings",
-        dest="max_findings",
-        type=int,
-        help="Maximum number of findings/details to surface per company (default: 10).",
-    )
-    parser.add_argument(
-        "--debug",
-        dest="debug",
-        action="store_true",
-        default=None,
-        help="Enable verbose debug logging and diagnostic payloads",
-    )
-    parser.add_argument(
-        "--allow-insecure-tls",
-        dest="allow_insecure_tls",
-        action="store_true",
-        default=None,
-        help=(
-            "Disable HTTPS certificate verification for BitSight API requests. "
-            "Use only when behind a trusted intercepting proxy."
-        ),
-    )
-    parser.add_argument(
-        "--ca-bundle",
-        dest="ca_bundle_path",
-        help=(
-            "Path to a custom CA bundle for BitSight API HTTPS verification "
-            "(overrides system trust store)."
-        ),
-    )
+_CONTEXT_CHOICES = {"standard", "risk_manager"}
+_LOG_FORMAT_CHOICES = {"text", "json"}
+_LOG_LEVEL_CHOICES = sorted(
+    name
+    for name, value in logging.getLevelNamesMapping().items()
+    if isinstance(name, str) and not name.isdigit()
+)
+_LOG_LEVEL_SET = {choice.upper() for choice in _LOG_LEVEL_CHOICES}
 
-    args = parser.parse_args()
 
-    logging_inputs = LoggingInputs(
-        level=args.log_level,
-        format=args.log_format,
-        file_path=args.log_file,
-        max_bytes=args.log_max_bytes,
-        backup_count=args.log_backup_count,
-    )
-
-    runtime_inputs = RuntimeInputs(
-        context=args.context,
-        debug=args.debug,
-        risk_vector_filter=args.risk_vector_filter,
-        max_findings=args.max_findings,
-        skip_startup_checks=args.skip_startup_checks,
-    )
-
-    subscription_inputs = SubscriptionInputs(
-        folder=args.subscription_folder,
-        type=args.subscription_type,
-    )
-
-    tls_inputs = TlsInputs(
-        allow_insecure=args.allow_insecure_tls,
-        ca_bundle_path=args.ca_bundle_path,
-    )
-
-    config_settings = load_settings(args.config_path)
-    apply_cli_overrides(
-        config_settings,
-        api_key_input=args.api_key,
-        subscription_inputs=subscription_inputs,
-        runtime_inputs=runtime_inputs,
-        tls_inputs=tls_inputs,
-        logging_inputs=logging_inputs,
-    )
-
-    runtime_settings = runtime_from_settings(config_settings)
-    logging_settings = logging_from_settings(config_settings)
-    if runtime_settings["debug"] and logging_settings.level > logging.DEBUG:
-        logging_settings = replace(logging_settings, level=logging.DEBUG)
-
-    print(
+def _banner() -> str:
+    return (
         "\n"
         "╭────────────────────────────────────────────────────────────────╮\n"
         "│\033[0;33m                                                                \033[0m│\n"
@@ -205,9 +65,300 @@ def main() -> None:
         "│\033[2m                   Bitsight Rating Retriever                    \033[0m│\n"
         "│\033[0;33m                 Model Context Protocol Server                  \033[0m│\n"
         "│\033[0;33m                https://github.com/boecht/birre                 \033[0m│\n"
-        "╰────────────────────────────────────────────────────────────────╯\n\033[0m",
-        file=sys.stderr,
+        "╰────────────────────────────────────────────────────────────────╯\n\033[0m"
     )
+
+
+def _keyboard_interrupt_banner() -> str:
+    return (
+        "\n"
+        "╭────────────────────────────────────────╮\n"
+        "│\033[0;31m  Keyboard interrupt received — stopping  \033[0m│\n"
+        "│\033[0;31m          BiRRe FastMCP server            \033[0m│\n"
+        "╰────────────────────────────────────────╯\n\033[0m"
+    )
+
+
+def _normalize_context(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    candidate = value.strip().lower().replace("-", "_")
+    if not candidate:
+        return None
+    if candidate not in _CONTEXT_CHOICES:
+        raise typer.BadParameter(
+            f"Context must be one of: {', '.join(sorted(_CONTEXT_CHOICES))}",
+            param_hint="--context",
+        )
+    return candidate
+
+
+def _normalize_log_format(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    candidate = value.strip().lower()
+    if not candidate:
+        return None
+    if candidate not in _LOG_FORMAT_CHOICES:
+        raise typer.BadParameter(
+            "Log format must be either 'text' or 'json'",
+            param_hint="--log-format",
+        )
+    return candidate
+
+
+def _normalize_log_level(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    candidate = value.strip().upper()
+    if not candidate:
+        return None
+    if candidate not in _LOG_LEVEL_SET:
+        raise typer.BadParameter(
+            f"Log level must be one of: {', '.join(_LOG_LEVEL_CHOICES)}",
+            param_hint="--log-level",
+        )
+    return candidate
+
+
+ApiKeyOption = Annotated[
+    Optional[str],
+    typer.Option(
+        "--bitsight-api-key",
+        help="BitSight API key (overrides BITSIGHT_API_KEY env var)",
+        envvar="BITSIGHT_API_KEY",
+        show_envvar=True,
+        rich_help_panel="Authentication",
+    ),
+]
+ConfigPathOption = Annotated[
+    str,
+    typer.Option(
+        "--config",
+        help="Path to BiRRe config TOML",
+        show_default=True,
+        rich_help_panel="Configuration",
+    ),
+]
+ContextOption = Annotated[
+    Optional[str],
+    typer.Option(
+        "--context",
+        help="Tool persona to expose (standard or risk_manager)",
+        envvar="BIRRE_CONTEXT",
+        show_envvar=True,
+        rich_help_panel="Runtime",
+    ),
+]
+LogLevelOption = Annotated[
+    Optional[str],
+    typer.Option(
+        "--log-level",
+        help="Logging level (defaults to INFO unless overridden)",
+        envvar="BIRRE_LOG_LEVEL",
+        show_envvar=True,
+        rich_help_panel="Logging",
+    ),
+]
+LogFormatOption = Annotated[
+    Optional[str],
+    typer.Option(
+        "--log-format",
+        help="Logging format (text or json)",
+        envvar="BIRRE_LOG_FORMAT",
+        show_envvar=True,
+        rich_help_panel="Logging",
+    ),
+]
+LogFileOption = Annotated[
+    Optional[str],
+    typer.Option(
+        "--log-file",
+        help="Log file path (adds rotating file handler)",
+        envvar="BIRRE_LOG_FILE",
+        show_envvar=True,
+        rich_help_panel="Logging",
+    ),
+]
+LogMaxBytesOption = Annotated[
+    Optional[int],
+    typer.Option(
+        "--log-max-bytes",
+        help="Maximum size in bytes for rotating log files",
+        envvar="BIRRE_LOG_MAX_BYTES",
+        show_envvar=True,
+        rich_help_panel="Logging",
+    ),
+]
+LogBackupCountOption = Annotated[
+    Optional[int],
+    typer.Option(
+        "--log-backup-count",
+        help="Number of rotating log file backups to keep",
+        envvar="BIRRE_LOG_BACKUP_COUNT",
+        show_envvar=True,
+        rich_help_panel="Logging",
+    ),
+]
+SkipStartupChecksOption = Annotated[
+    Optional[bool],
+    typer.Option(
+        "--skip-startup-checks/--no-skip-startup-checks",
+        help="Skip BitSight startup checks (not recommended)",
+        envvar="BIRRE_SKIP_STARTUP_CHECKS",
+        show_envvar=True,
+        rich_help_panel="Runtime",
+    ),
+]
+SubscriptionFolderOption = Annotated[
+    Optional[str],
+    typer.Option(
+        "--subscription-folder",
+        help="Preferred BitSight subscription folder name (e.g. API), must exist",
+        envvar="BIRRE_SUBSCRIPTION_FOLDER",
+        show_envvar=True,
+        rich_help_panel="BitSight",
+    ),
+]
+SubscriptionTypeOption = Annotated[
+    Optional[str],
+    typer.Option(
+        "--subscription-type",
+        help="BitSight subscription type (e.g. continuous_monitoring)",
+        envvar="BIRRE_SUBSCRIPTION_TYPE",
+        show_envvar=True,
+        rich_help_panel="BitSight",
+    ),
+]
+RiskVectorFilterOption = Annotated[
+    Optional[str],
+    typer.Option(
+        "--risk-vector-filter",
+        help="Override the default risk vectors used for top findings (comma-separated).",
+        envvar="BIRRE_RISK_VECTOR_FILTER",
+        show_envvar=True,
+        rich_help_panel="Runtime",
+    ),
+]
+MaxFindingsOption = Annotated[
+    Optional[int],
+    typer.Option(
+        "--max-findings",
+        help="Maximum number of findings/details to surface per company (default: 10).",
+        envvar="BIRRE_MAX_FINDINGS",
+        show_envvar=True,
+        rich_help_panel="Runtime",
+    ),
+]
+DebugOption = Annotated[
+    Optional[bool],
+    typer.Option(
+        "--debug/--no-debug",
+        help="Enable verbose debug logging and diagnostic payloads",
+        envvar="BIRRE_DEBUG",
+        show_envvar=True,
+        rich_help_panel="Runtime",
+    ),
+]
+AllowInsecureTlsOption = Annotated[
+    Optional[bool],
+    typer.Option(
+        "--allow-insecure-tls/--require-secure-tls",
+        help=(
+            "Disable HTTPS certificate verification for BitSight API requests. "
+            "Use only when behind a trusted intercepting proxy."
+        ),
+        envvar="BIRRE_ALLOW_INSECURE_TLS",
+        show_envvar=True,
+        rich_help_panel="TLS",
+    ),
+]
+CaBundleOption = Annotated[
+    Optional[str],
+    typer.Option(
+        "--ca-bundle",
+        help=(
+            "Path to a custom CA bundle for BitSight API HTTPS verification "
+            "(overrides system trust store)."
+        ),
+        envvar="BIRRE_CA_BUNDLE",
+        show_envvar=True,
+        rich_help_panel="TLS",
+    ),
+]
+
+
+def _run_server(
+    *,
+    api_key: Optional[str],
+    config_path: str,
+    context: Optional[str],
+    log_level: Optional[str],
+    log_format: Optional[str],
+    log_file: Optional[str],
+    log_max_bytes: Optional[int],
+    log_backup_count: Optional[int],
+    skip_startup_checks: Optional[bool],
+    subscription_folder: Optional[str],
+    subscription_type: Optional[str],
+    risk_vector_filter: Optional[str],
+    max_findings: Optional[int],
+    debug: Optional[bool],
+    allow_insecure_tls: Optional[bool],
+    ca_bundle_path: Optional[str],
+    context_alias: Optional[str] = None,
+) -> None:
+    alias_context = _normalize_context(context_alias) if context_alias else None
+    requested_context = _normalize_context(context)
+    if alias_context and requested_context and alias_context != requested_context:
+        raise typer.BadParameter(
+            f"Context '{requested_context}' conflicts with the '{alias_context}' command.",
+            param_hint="--context",
+        )
+    normalized_context = alias_context or requested_context
+
+    normalized_log_format = _normalize_log_format(log_format)
+    normalized_log_level = _normalize_log_level(log_level)
+
+    logging_inputs = LoggingInputs(
+        level=normalized_log_level,
+        format=normalized_log_format,
+        file_path=log_file,
+        max_bytes=log_max_bytes,
+        backup_count=log_backup_count,
+    )
+    runtime_inputs = RuntimeInputs(
+        context=normalized_context,
+        debug=debug,
+        risk_vector_filter=risk_vector_filter,
+        max_findings=max_findings,
+        skip_startup_checks=skip_startup_checks,
+    )
+    subscription_inputs = SubscriptionInputs(
+        folder=subscription_folder,
+        type=subscription_type,
+    )
+    tls_inputs = TlsInputs(
+        allow_insecure=allow_insecure_tls,
+        ca_bundle_path=ca_bundle_path,
+    )
+
+    config_settings = load_settings(config_path)
+    apply_cli_overrides(
+        config_settings,
+        api_key_input=api_key,
+        subscription_inputs=subscription_inputs,
+        runtime_inputs=runtime_inputs,
+        tls_inputs=tls_inputs,
+        logging_inputs=logging_inputs,
+    )
+
+    runtime_settings = runtime_from_settings(config_settings)
+    logging_settings = logging_from_settings(config_settings)
+    if runtime_settings["debug"] and logging_settings.level > logging.DEBUG:
+        logging_settings = replace(logging_settings, level=logging.DEBUG)
+
+    console.print(_banner(), markup=False)
 
     configure_logging(logging_settings)
     logger = logging.getLogger("birre")
@@ -233,6 +384,11 @@ def main() -> None:
     server = create_birre_server(settings=runtime_settings, logger=logger)
 
     logger.info("Running online startup checks")
+    skip_checks = (
+        skip_startup_checks
+        if skip_startup_checks is not None
+        else runtime_settings["skip_startup_checks"]
+    )
     call_v1_tool = getattr(server, "call_v1_tool", None)
     online_ok = asyncio.run(
         run_online_startup_checks(
@@ -240,9 +396,7 @@ def main() -> None:
             subscription_folder=runtime_settings["subscription_folder"],
             subscription_type=runtime_settings["subscription_type"],
             logger=logger,
-            skip_startup_checks=(
-                args.skip_startup_checks or runtime_settings["skip_startup_checks"]
-            ),
+            skip_startup_checks=skip_checks,
         )
     )
     if not online_ok:
@@ -253,15 +407,167 @@ def main() -> None:
     try:
         server.run()
     except KeyboardInterrupt:
-        print(
-            "\n"
-            "╭────────────────────────────────────────╮\n"
-            "│\033[0;31m  Keyboard interrupt received — stopping  \033[0m│\n"
-            "│\033[0;31m          BiRRe FastMCP server            \033[0m│\n"
-            "╰────────────────────────────────────────╯\n\033[0m",
-            file=sys.stderr,
-        )
+        console.print(_keyboard_interrupt_banner(), markup=False)
         logger.info("BiRRe FastMCP server stopped via KeyboardInterrupt")
+
+
+@app.command(help="Serve BiRRe with an explicitly selected context.")
+def serve(
+    api_key: ApiKeyOption = None,
+    config_path: ConfigPathOption = DEFAULT_CONFIG_FILENAME,
+    context: ContextOption = None,
+    log_level: LogLevelOption = None,
+    log_format: LogFormatOption = None,
+    log_file: LogFileOption = None,
+    log_max_bytes: LogMaxBytesOption = None,
+    log_backup_count: LogBackupCountOption = None,
+    skip_startup_checks: SkipStartupChecksOption = None,
+    subscription_folder: SubscriptionFolderOption = None,
+    subscription_type: SubscriptionTypeOption = None,
+    risk_vector_filter: RiskVectorFilterOption = None,
+    max_findings: MaxFindingsOption = None,
+    debug: DebugOption = None,
+    allow_insecure_tls: AllowInsecureTlsOption = None,
+    ca_bundle_path: CaBundleOption = None,
+) -> None:
+    """Run the BiRRe FastMCP server."""
+
+    _run_server(
+        api_key=api_key,
+        config_path=config_path,
+        context=context,
+        log_level=log_level,
+        log_format=log_format,
+        log_file=log_file,
+        log_max_bytes=log_max_bytes,
+        log_backup_count=log_backup_count,
+        skip_startup_checks=skip_startup_checks,
+        subscription_folder=subscription_folder,
+        subscription_type=subscription_type,
+        risk_vector_filter=risk_vector_filter,
+        max_findings=max_findings,
+        debug=debug,
+        allow_insecure_tls=allow_insecure_tls,
+        ca_bundle_path=ca_bundle_path,
+    )
+
+
+@app.command(help="Serve BiRRe using the standard tool persona.")
+def standard(
+    api_key: ApiKeyOption = None,
+    config_path: ConfigPathOption = DEFAULT_CONFIG_FILENAME,
+    log_level: LogLevelOption = None,
+    log_format: LogFormatOption = None,
+    log_file: LogFileOption = None,
+    log_max_bytes: LogMaxBytesOption = None,
+    log_backup_count: LogBackupCountOption = None,
+    skip_startup_checks: SkipStartupChecksOption = None,
+    subscription_folder: SubscriptionFolderOption = None,
+    subscription_type: SubscriptionTypeOption = None,
+    risk_vector_filter: RiskVectorFilterOption = None,
+    max_findings: MaxFindingsOption = None,
+    debug: DebugOption = None,
+    allow_insecure_tls: AllowInsecureTlsOption = None,
+    ca_bundle_path: CaBundleOption = None,
+) -> None:
+    """Run the BiRRe FastMCP server in the standard context."""
+
+    _run_server(
+        api_key=api_key,
+        config_path=config_path,
+        context=None,
+        log_level=log_level,
+        log_format=log_format,
+        log_file=log_file,
+        log_max_bytes=log_max_bytes,
+        log_backup_count=log_backup_count,
+        skip_startup_checks=skip_startup_checks,
+        subscription_folder=subscription_folder,
+        subscription_type=subscription_type,
+        risk_vector_filter=risk_vector_filter,
+        max_findings=max_findings,
+        debug=debug,
+        allow_insecure_tls=allow_insecure_tls,
+        ca_bundle_path=ca_bundle_path,
+        context_alias="standard",
+    )
+
+
+@app.command("risk-manager", help="Serve BiRRe using the risk manager persona.")
+def risk_manager(
+    api_key: ApiKeyOption = None,
+    config_path: ConfigPathOption = DEFAULT_CONFIG_FILENAME,
+    log_level: LogLevelOption = None,
+    log_format: LogFormatOption = None,
+    log_file: LogFileOption = None,
+    log_max_bytes: LogMaxBytesOption = None,
+    log_backup_count: LogBackupCountOption = None,
+    skip_startup_checks: SkipStartupChecksOption = None,
+    subscription_folder: SubscriptionFolderOption = None,
+    subscription_type: SubscriptionTypeOption = None,
+    risk_vector_filter: RiskVectorFilterOption = None,
+    max_findings: MaxFindingsOption = None,
+    debug: DebugOption = None,
+    allow_insecure_tls: AllowInsecureTlsOption = None,
+    ca_bundle_path: CaBundleOption = None,
+) -> None:
+    """Run the BiRRe FastMCP server in the risk manager context."""
+
+    _run_server(
+        api_key=api_key,
+        config_path=config_path,
+        context=None,
+        log_level=log_level,
+        log_format=log_format,
+        log_file=log_file,
+        log_max_bytes=log_max_bytes,
+        log_backup_count=log_backup_count,
+        skip_startup_checks=skip_startup_checks,
+        subscription_folder=subscription_folder,
+        subscription_type=subscription_type,
+        risk_vector_filter=risk_vector_filter,
+        max_findings=max_findings,
+        debug=debug,
+        allow_insecure_tls=allow_insecure_tls,
+        ca_bundle_path=ca_bundle_path,
+        context_alias="risk_manager",
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Main entry point for BiRRe MCP server."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        _run_server(
+            api_key=None,
+            config_path=DEFAULT_CONFIG_FILENAME,
+            context=None,
+            log_level=None,
+            log_format=None,
+            log_file=None,
+            log_max_bytes=None,
+            log_backup_count=None,
+            skip_startup_checks=None,
+            subscription_folder=None,
+            subscription_type=None,
+            risk_vector_filter=None,
+            max_findings=None,
+            debug=None,
+            allow_insecure_tls=None,
+            ca_bundle_path=None,
+        )
+        return
+
+    command = get_command(app)
+    if args[0] in {"-h", "--help"}:
+        command.main(args=args, prog_name="server.py")
+        return
+
+    if args[0].startswith("-"):
+        command.main(args=["serve", *args], prog_name="server.py")
+    else:
+        command.main(args=args, prog_name="server.py")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace the argparse-based entrypoint with a Typer application that validates options and exposes context-specific subcommands
- add reusable option definitions with environment variable support and shared runtime bootstrap logic
- depend on typer, rich, and typing_extensions for the new CLI implementation

## Testing
- uv run pytest -m "not live" -v

------
https://chatgpt.com/codex/tasks/task_e_68f56badbd38832c8073b306ebf32cea