### PR TITLE
Include server module in package build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,5 +34,8 @@ where = ["src"]
 [tool.setuptools.package-dir]
 "" = "src"
 
+[tool.setuptools]
+py-modules = ["server"]
+
 [project.scripts]
 birre = "server:main"


### PR DESCRIPTION
## Summary
- ensure the standalone server module is packaged with BiRRe distributions so the `birre` console script can import it on Windows

## Testing
- `uv run pytest -m "not live" -v`


------
https://chatgpt.com/codex/tasks/task_e_68f8bd17df80832c83204d76c72b8008