### PR TITLE
Remove deprecated Typer flag parameters

### DIFF
--- a/server.py
+++ b/server.py
@@ -316,7 +316,6 @@ OfflineFlagOption = Annotated[
         "--offline",
         help="Skip BitSight network checks and run offline validation only",
         rich_help_panel="Diagnostics",
-        is_flag=True,
     ),
 ]
 
@@ -326,7 +325,6 @@ ProductionFlagOption = Annotated[
         "--production",
         help="Use the BitSight production API for online validation",
         rich_help_panel="Diagnostics",
-        is_flag=True,
     ),
 ]
 


### PR DESCRIPTION
## Summary
- drop the deprecated `is_flag` configuration from the CLI flag options so Typer no longer emits warnings during startup

## Testing
- python server.py healthcheck --help

------
https://chatgpt.com/codex/tasks/task_e_68fb20bf1714832c92f6818d71bdc4d8