### PR TITLE
fix(ci): grant permissions for release workflow

### DIFF
--- a/.github/workflows/build-sign-publish.yml
+++ b/.github/workflows/build-sign-publish.yml
@@ -15,6 +15,8 @@ name: Build, Sign & Publish
 permissions:
   contents: write
   id-token: write # Required for PyPI trusted publishing
+  pull-requests: write # Reusable lint workflow posts summaries
+  statuses: write # Allow MegaLinter to update commit statuses
 
 jobs:
   quality-lint:


### PR DESCRIPTION
## Summary
- add pull request and status permissions so the reusable lint workflow can run during releases

## Testing
- n/a (workflow-only change)