### PR TITLE
fix(ci): allow sarif uploads in release workflow

### DIFF
--- a/.github/workflows/build-sign-publish.yml
+++ b/.github/workflows/build-sign-publish.yml
@@ -17,6 +17,7 @@ permissions:
   id-token: write # Required for PyPI trusted publishing
   pull-requests: write # Reusable lint workflow posts summaries
   statuses: write # Allow MegaLinter to update commit statuses
+  security-events: write # Allow SARIF uploads from reusable workflow
 
 jobs:
   quality-lint:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -56,6 +56,7 @@ name: Lint, Type, Test & SBOM Gate
 permissions:
   contents: read
   pull-requests: write
+  security-events: write
 
 jobs:
   dependency-review:


### PR DESCRIPTION
## Summary
- grant security-events write permission so upload-sarif step succeeds during releases

## Testing
- n/a (workflow-only change)