### PR TITLE
fix(ci): allow sarif upload in reusable lint workflow

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -87,6 +87,7 @@ jobs:
       contents: read
       pull-requests: write
       statuses: write
+      security-events: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- add security-events write permission to the lint job in the reusable workflow so SARIF uploads succeed during releases

## Testing
- n/a (workflow change only)