### PR TITLE
fix(ci): skip trusted publish for prereleases

### DIFF
--- a/.github/workflows/build-sign-publish.yml
+++ b/.github/workflows/build-sign-publish.yml
@@ -118,6 +118,8 @@ jobs:
     name: Create GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    outputs:
+      prerelease: ${{ steps.version.outputs.prerelease }}
 
     steps:
       - name: Checkout repository
@@ -211,6 +213,7 @@ jobs:
     name: Publish to PyPI
     needs: github-release
     runs-on: ubuntu-latest
+    if: ${{ needs.github-release.outputs.prerelease == 'false' }}
     environment:
       name: release
       url: https://pypi.org/project/birre/


### PR DESCRIPTION
## Summary
- surface the release job's prerelease flag as a job output and use it to gate the PyPI publish step
- prerelease tags (like v4.0.0-alpha.2) now stop after signing + GitHub release so trusted publishing no longer fails

## Testing
- n/a (workflow change only)