### PR TITLE
fix(ci): ignore sbom in pypi publish step

### DIFF
--- a/.github/workflows/build-sign-publish.yml
+++ b/.github/workflows/build-sign-publish.yml
@@ -222,6 +222,10 @@ jobs:
           name: dist
           path: dist/
 
+      - name: Remove non-distribution artifacts
+        run: |
+          find dist -type f ! -name '*.whl' ! -name '*.tar.gz' -delete
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
## Summary
- delete non-distribution artifacts (e.g., SBOM JSON) before calling gh-action-pypi-publish so trusted publishing only sees wheel/sdist files

## Testing
- n/a (workflow-only change)